### PR TITLE
Add usb audio device example

### DIFF
--- a/examples/audio/Makefile
+++ b/examples/audio/Makefile
@@ -1,0 +1,7 @@
+TARGET    = audio
+LIBFX2DIR = ../../third_party/libfx2
+LIBRARIES = fx2 fx2usb fx2isrs
+FLAGS     = -I../../common -DDEBUG
+SOURCES   = main descriptors ../../common/uac
+
+include ../../common/common.mk

--- a/examples/audio/descriptors.c
+++ b/examples/audio/descriptors.c
@@ -1,0 +1,56 @@
+#include <fx2lib.h>
+#include <fx2usb.h>
+
+#include "uac.h"
+
+usb_ascii_string_c usb_strings[] = {
+  "TimVideos.us",
+  "USB Audio Class example",
+  "Left",
+  "Right",
+};
+
+usb_desc_device_c usb_device = {
+  .bLength              = sizeof(struct usb_desc_device),
+  .bDescriptorType      = USB_DESC_DEVICE,
+  .bcdUSB               = 0x0200,
+  .bDeviceClass         = USB_DEV_CLASS_MISCELLANEOUS,
+  .bDeviceSubClass      = USB_DEV_SUBCLASS_COMMON,
+  .bDeviceProtocol      = USB_DEV_PROTOCOL_INTERFACE_ASSOCIATION_DESCRIPTOR,
+  .bMaxPacketSize0      = 64,
+  .idVendor             = VID,  // VID, PID, DID defined by compiler flags depending on BOARD
+  .idProduct            = PID,
+  .bcdDevice            = DID,
+  .iManufacturer        = 1,
+  .iProduct             = 2,
+  .iSerialNumber        = 0,
+  .bNumConfigurations   = 1,
+};
+
+usb_configuration_c usb_config = {
+  {
+    .bLength              = sizeof(struct usb_desc_configuration),
+    .bDescriptorType      = USB_DESC_CONFIGURATION,
+    .bNumInterfaces       = UAC_NUM_INTERFACES,
+    .bConfigurationValue  = 1,
+    .iConfiguration       = 0,
+    .bmAttributes         = USB_ATTR_RESERVED_1,
+    .bMaxPower            = 250, // 500mA
+  },
+  {
+    UAC_DESCRIPTORS_LIST
+    { 0 }
+  }
+};
+
+usb_configuration_set_c usb_configs[] = {
+  &usb_config,
+};
+
+usb_descriptor_set_c usb_descriptor_set = {
+  .device           = &usb_device,
+  .config_count     = ARRAYSIZE(usb_configs),
+  .configs          = usb_configs,
+  .string_count     = ARRAYSIZE(usb_strings),
+  .strings          = usb_strings,
+};

--- a/examples/audio/main.c
+++ b/examples/audio/main.c
@@ -1,0 +1,52 @@
+#include <fx2lib.h>
+#include <fx2delay.h>
+#include <fx2usb.h>
+
+#include "uac.h"
+
+int main() {
+  // Run core at 48 MHz fCLK.
+  CPUCS = _CLKSPD1;
+
+  // Configure descriptors
+  {
+    __xdata struct uac_configuration config = {
+      .if_num_ctrl = 0,  // interface numbers start from 0
+      .ep_addr_streaming = 2,  // use EP2 for streaming interface
+      .i_str_channel_left = 3,
+    };
+    uac_config(&config);
+  }
+
+  // Configure UAC endpoint: 512-byte, double buffered, ISOCHRONOUS IN
+  SYNCDELAY;
+  EP2CFG = _VALID|_DIR|_TYPE0|_BUF1;
+
+  // Re-enumerate, to make sure our descriptors are picked up correctly.
+  usb_init(/*disconnect=*/true);
+
+  while (1) {
+
+  }
+}
+
+/*** Reimplemented libfx2 USB handlers ****************************************/
+
+// USB setup commands
+void handle_usb_setup(__xdata struct usb_req_setup *req) {
+  STALL_EP0(); // not handled
+}
+
+// Set active interface _alternate setting_
+bool handle_usb_set_interface(uint8_t interface, uint8_t alt_setting) {
+  if (uac_handle_usb_set_interface(interface, alt_setting))
+    return true;
+  return false; // not handled
+}
+
+// Set current interface _alternate setting_
+void handle_usb_get_interface(uint8_t interface) {
+  if (uac_handle_usb_get_interface(interface))
+    return;
+  STALL_EP0(); // not handled
+}


### PR DESCRIPTION
This implements USB Audio Class device example. 

Most of the code for UAC is located in `common/`:
* https://github.com/antmicro/HDMI2USB-fx2-firmware/blob/21e2e49e252dcbe010cf098253d84d43f0ce2e47/common/uac.h
* https://github.com/antmicro/HDMI2USB-fx2-firmware/blob/21e2e49e252dcbe010cf098253d84d43f0ce2e47/common/uac.c

and the example just pulls it together.

In current approach the descriptors required for UAC are defined in `uac.c` and added to descriptors set using `UAC_DESCRIPTORS_LIST` macro. They are then modified in `uac_config` during initialization. 

If this is to be merged back to *libfx2*, this approach may not be flexible enough and we may instead want to provide multiple `#define` macros for descriptors initialization directly in user code. 