### PR TITLE
Add usb video device example

### DIFF
--- a/examples/video/Makefile
+++ b/examples/video/Makefile
@@ -1,0 +1,7 @@
+TARGET    = video
+LIBFX2DIR = ../../third_party/libfx2
+LIBRARIES = fx2 fx2usb fx2isrs
+FLAGS     = -I../../common -DDEBUG
+SOURCES   = main descriptors ../../common/uvc
+
+include ../../common/common.mk

--- a/examples/video/descriptors.c
+++ b/examples/video/descriptors.c
@@ -1,0 +1,56 @@
+#include <fx2lib.h>
+#include <fx2usb.h>
+
+#include "uvc.h"
+
+usb_ascii_string_c usb_strings[] = {
+  "TimVideos.us",
+  "USB Audio Class example",
+  "Left",
+  "Right",
+};
+
+usb_desc_device_c usb_device = {
+  .bLength              = sizeof(struct usb_desc_device),
+  .bDescriptorType      = USB_DESC_DEVICE,
+  .bcdUSB               = 0x0200,
+  .bDeviceClass         = USB_DEV_CLASS_MISCELLANEOUS,
+  .bDeviceSubClass      = USB_DEV_SUBCLASS_COMMON,
+  .bDeviceProtocol      = USB_DEV_PROTOCOL_INTERFACE_ASSOCIATION_DESCRIPTOR,
+  .bMaxPacketSize0      = 64,
+  .idVendor             = VID,  // VID, PID, DID defined by compiler flags depending on BOARD
+  .idProduct            = PID,
+  .bcdDevice            = DID,
+  .iManufacturer        = 1,
+  .iProduct             = 2,
+  .iSerialNumber        = 0,
+  .bNumConfigurations   = 1,
+};
+
+usb_configuration_c usb_config = {
+  {
+    .bLength              = sizeof(struct usb_desc_configuration),
+    .bDescriptorType      = USB_DESC_CONFIGURATION,
+    .bNumInterfaces       = UVC_NUM_INTERFACES,
+    .bConfigurationValue  = 1,
+    .iConfiguration       = 0,
+    .bmAttributes         = USB_ATTR_RESERVED_1,
+    .bMaxPower            = 250, // 500mA
+  },
+  {
+    UVC_DESCRIPTORS_LIST
+    { 0 }
+  }
+};
+
+usb_configuration_set_c usb_configs[] = {
+  &usb_config,
+};
+
+usb_descriptor_set_c usb_descriptor_set = {
+  .device           = &usb_device,
+  .config_count     = ARRAYSIZE(usb_configs),
+  .configs          = usb_configs,
+  .string_count     = ARRAYSIZE(usb_strings),
+  .strings          = usb_strings,
+};

--- a/examples/video/main.c
+++ b/examples/video/main.c
@@ -1,0 +1,39 @@
+#include <fx2lib.h>
+#include <fx2delay.h>
+#include <fx2usb.h>
+
+#include "uvc.h"
+
+int main() {
+  // Run core at 48 MHz fCLK.
+  CPUCS = _CLKSPD1;
+
+  // Configure descriptors
+  {
+    __xdata struct uvc_configuration config = {
+      .if_num_ctrl = 0,  // interface numbers start from 0
+      .ep_addr_streaming = 2,  // use EP2 for streaming interface
+    };
+    uvc_config(&config);
+  }
+
+  // Configure UVC endpoint: 512-byte, double buffered, ISOCHRONOUS IN
+  SYNCDELAY;
+  EP2CFG = _VALID|_DIR|_TYPE0|_BUF1;
+
+  // Re-enumerate, to make sure our descriptors are picked up correctly.
+  usb_init(/*disconnect=*/true);
+
+  while (1) {
+
+  }
+}
+
+/*** Reimplemented libfx2 USB handlers ****************************************/
+
+// USB setup commands
+void handle_usb_setup(__xdata struct usb_req_setup *req) {
+  if (uvc_handle_usb_setup(req))
+    return;
+  STALL_EP0(); // not handled
+}


### PR DESCRIPTION
This implements USB Video Class device example.

The pull request is analogous to https://github.com/antmicro/HDMI2USB-fx2-firmware/pull/1. The same question about the code structure arises. In this example most UVC code resides in `common/uvc.c` and `common/uvc.h`.